### PR TITLE
Convert builtin errors to EvalErrors

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -36,7 +36,11 @@ func (c *cache) starlark_once(thread *starlark.Thread, fn *starlark.Builtin, arg
 		return nil, err
 	}
 	
-	return c.once(thread, fn, key, function)
+	val, err := c.once(thread, fn, key, function)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -59,7 +63,11 @@ func (proj *Project) starlark_builtin_path(thread *starlark.Thread, fn *starlark
 		return nil, err
 	}
 	
-	return proj.builtin_path(thread, fn, rawlabel)
+	val, err := proj.builtin_path(thread, fn, rawlabel)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -82,7 +90,11 @@ func (proj *Project) starlark_builtin_label(thread *starlark.Thread, fn *starlar
 		return nil, err
 	}
 	
-	return proj.builtin_label(thread, fn, path)
+	val, err := proj.builtin_label(thread, fn, path)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -107,7 +119,11 @@ func (proj *Project) starlark_builtin_contains(thread *starlark.Thread, fn *star
 		return nil, err
 	}
 	
-	return proj.builtin_contains(thread, fn, path)
+	val, err := proj.builtin_contains(thread, fn, path)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -149,7 +165,11 @@ func (proj *Project) starlark_builtin_parse_flag(thread *starlark.Thread, fn *st
 		return nil, err
 	}
 	
-	return proj.builtin_parse_flag(thread, fn, name, default_, type_, choices, required, help)
+	val, err := proj.builtin_parse_flag(thread, fn, name, default_, type_, choices, required, help)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -207,7 +227,11 @@ func (proj *Project) starlark_builtin_target(thread *starlark.Thread, fn *starla
 		return nil, err
 	}
 	
-	return proj.builtin_target(thread, fn, name, deps, sources, generates, function, default_, always, docs)
+	val, err := proj.builtin_target(thread, fn, name, deps, sources, generates, function, default_, always, docs)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -243,7 +267,11 @@ func (proj *Project) starlark_builtin_glob(thread *starlark.Thread, fn *starlark
 		return nil, err
 	}
 	
-	return proj.builtin_glob(thread, fn, include, exclude)
+	val, err := proj.builtin_glob(thread, fn, include, exclude)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -278,7 +306,11 @@ func (proj *Project) starlark_builtin_run(thread *starlark.Thread, fn *starlark.
 		return nil, err
 	}
 	
-	return proj.builtin_run(thread, fn, labelOrTarget, always, dryRun, callback)
+	val, err := proj.builtin_run(thread, fn, labelOrTarget, always, dryRun, callback)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -305,7 +337,11 @@ func (proj *Project) starlark_builtin_get_target(thread *starlark.Thread, fn *st
 		return nil, err
 	}
 	
-	return proj.builtin_get_target(thread, fn, rawlabel)
+	val, err := proj.builtin_get_target(thread, fn, rawlabel)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -323,7 +359,11 @@ func (proj *Project) starlark_builtin_flags(thread *starlark.Thread, fn *starlar
 		return nil, err
 	}
 	
-	return proj.builtin_flags(thread, fn)
+	val, err := proj.builtin_flags(thread, fn)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -341,7 +381,11 @@ func (proj *Project) starlark_builtin_targets(thread *starlark.Thread, fn *starl
 		return nil, err
 	}
 	
-	return proj.builtin_targets(thread, fn)
+	val, err := proj.builtin_targets(thread, fn)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -359,7 +403,11 @@ func (proj *Project) starlark_builtin_sources(thread *starlark.Thread, fn *starl
 		return nil, err
 	}
 	
-	return proj.builtin_sources(thread, fn)
+	val, err := proj.builtin_sources(thread, fn)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -382,7 +430,11 @@ func (proj *Project) starlark_builtin_fail(thread *starlark.Thread, fn *starlark
 		return nil, err
 	}
 	
-	return proj.builtin_fail(thread, fn, message)
+	val, err := proj.builtin_fail(thread, fn, message)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 

--- a/cmd/dawn-gen-builtins/function_wrappers.tmpl
+++ b/cmd/dawn-gen-builtins/function_wrappers.tmpl
@@ -32,7 +32,11 @@ func {{with .Receiver}}({{.Name}} {{.Type}}) {{end}}{{.FunctionName}}(thread *st
 		return nil, err
 	}
 	{{end}}
-	return {{with .Receiver}}{{.Name}}.{{end}}{{.Name}}(thread, fn{{range .Params}}, {{.Name}}{{end}})
+	val, err := {{with .Receiver}}{{.Name}}.{{end}}{{.Name}}(thread, fn{{range .Params}}, {{.Name}}{{end}})
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 {{end}}
 {{end}}

--- a/cmd/dawn/builtins.go
+++ b/cmd/dawn/builtins.go
@@ -35,7 +35,11 @@ func (w *workspace) starlark_builtin_depends(thread *starlark.Thread, fn *starla
 		return nil, err
 	}
 	
-	return w.builtin_depends(thread, fn, labelOrTarget)
+	val, err := w.builtin_depends(thread, fn, labelOrTarget)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -62,7 +66,11 @@ func (w *workspace) starlark_builtin_whatDepends(thread *starlark.Thread, fn *st
 		return nil, err
 	}
 	
-	return w.builtin_whatDepends(thread, fn, labelOrTarget)
+	val, err := w.builtin_whatDepends(thread, fn, labelOrTarget)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 

--- a/lib/os/builtins.go
+++ b/lib/os/builtins.go
@@ -28,7 +28,11 @@ func Environ(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple,
 		return nil, err
 	}
 	
-	return environ(thread, fn)
+	val, err := environ(thread, fn)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -58,7 +62,11 @@ func LookPath(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple
 		return nil, err
 	}
 	
-	return lookPath(thread, fn, file)
+	val, err := lookPath(thread, fn, file)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -100,7 +108,11 @@ func Exec(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kw
 		return nil, err
 	}
 	
-	return execf(thread, fn, cmdV, cwd, envV, try)
+	val, err := execf(thread, fn, cmdV, cwd, envV, try)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -144,7 +156,11 @@ func Output(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, 
 		return nil, err
 	}
 	
-	return output(thread, fn, cmdV, cwd, envV, try)
+	val, err := output(thread, fn, cmdV, cwd, envV, try)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -167,7 +183,11 @@ func Exists(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, 
 		return nil, err
 	}
 	
-	return exists(thread, fn, path)
+	val, err := exists(thread, fn, path)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -186,7 +206,11 @@ func Getcwd(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, 
 		return nil, err
 	}
 	
-	return getcwd(thread, fn)
+	val, err := getcwd(thread, fn)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -211,7 +235,11 @@ func Mkdir(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, k
 		return nil, err
 	}
 	
-	return mkdir(thread, fn, path, mode)
+	val, err := mkdir(thread, fn, path, mode)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -237,7 +265,11 @@ func Makedirs(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple
 		return nil, err
 	}
 	
-	return makedirs(thread, fn, path, mode)
+	val, err := makedirs(thread, fn, path, mode)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -272,7 +304,11 @@ func Glob(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kw
 		return nil, err
 	}
 	
-	return glob(thread, fn, include, exclude)
+	val, err := glob(thread, fn, include, exclude)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 

--- a/lib/os/path/builtins.go
+++ b/lib/os/path/builtins.go
@@ -33,7 +33,11 @@ func Abs(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwa
 		return nil, err
 	}
 	
-	return abs(thread, fn, path)
+	val, err := abs(thread, fn, path)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -56,7 +60,11 @@ func IsAbs(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, k
 		return nil, err
 	}
 	
-	return isAbs(thread, fn, path)
+	val, err := isAbs(thread, fn, path)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -82,7 +90,11 @@ func Base(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kw
 		return nil, err
 	}
 	
-	return base(thread, fn, path)
+	val, err := base(thread, fn, path)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -108,7 +120,11 @@ func Dir(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwa
 		return nil, err
 	}
 	
-	return dir(thread, fn, path)
+	val, err := dir(thread, fn, path)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -143,7 +159,11 @@ func Split(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, k
 		return nil, err
 	}
 	
-	return split(thread, fn, path)
+	val, err := split(thread, fn, path)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -169,7 +189,11 @@ func Splitext(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple
 		return nil, err
 	}
 	
-	return splitext(thread, fn, path)
+	val, err := splitext(thread, fn, path)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 

--- a/lib/sh/builtins.go
+++ b/lib/sh/builtins.go
@@ -50,7 +50,11 @@ func Exec(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kw
 		return nil, err
 	}
 	
-	return exec(thread, fn, cmd, cwd, env, try)
+	val, err := exec(thread, fn, cmd, cwd, env, try)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 
@@ -95,7 +99,11 @@ func Output(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, 
 		return nil, err
 	}
 	
-	return output(thread, fn, cmd, cwd, env, try)
+	val, err := output(thread, fn, cmd, cwd, env, try)
+	if err != nil {
+		return nil, &starlark.EvalError{Msg: err.Error(), CallStack: thread.CallStack()}
+	}
+	return val, nil
 }
 
 


### PR DESCRIPTION
This allows us to capture a stacktrace with the error so that failures
indicate the line of the failing expression.